### PR TITLE
Increase timeout for helm releases

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # Default Applications directory
 
 helm_apps_dir := "apps"
-helm_timeout := "1m"
+helm_timeout := "555m"
 
 # Kind configuration
 


### PR DESCRIPTION
Increase timeout on helm, just in case the workstation takes longer pulling container images.